### PR TITLE
한재엽님 블로그 도메인 변경

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 ## 블로그
 
 - [PoiemaWeb](https://poiemaweb.com) - 이웅모님의 웹 개발 튜토리얼
-- [JBEE](https://jaeyeophan.github.io/categories/TypeScript) - 타입스크립트 코리아 한재엽님의 블로그
+- [JBEE](https://blog.jbee.io/typescript/0.+Quick+Start) - 타입스크립트 코리아 한재엽님의 블로그
 - [DailyEngineering](https://hyunseob.github.io/categories/JavaScript/TypeScript) - 타입스크립트 코리아 이현섭님의 블로그
 
 ## 책


### PR DESCRIPTION
한재엽님의 블로그 주소가 https://jaeyeophan.github.io 에서 https://blog.jbee.io 로 변경되었습니다